### PR TITLE
HTML-escaping of xss payload in User prefix field

### DIFF
--- a/src/web/users-creation.jsp
+++ b/src/web/users-creation.jsp
@@ -8,6 +8,8 @@
                  java.util.Map"
 %>
 
+<%@ page import="org.apache.commons.text.StringEscapeUtils"%>
+
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
@@ -113,7 +115,7 @@
         <tr class="c1">
             <td width="1%" colspan="2" nowrap>
                 User prefix:
-                &nbsp;<input type="text" name="prefix" value="<%=(prefix != null ? prefix : "user") %>" size="30" maxlength="75"/>
+                &nbsp;<input type="text" name="prefix" value="<%=  StringEscapeUtils.escapeHtml4(prefix != null ? prefix : "user") %>" size="30" maxlength="75"/>
             </td>
         </tr>
         <tr class="c1">


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-other-openfire-userCreation-plugin/

### ⚙️ Description *

In the page to create and view a new created user, the (dangerous)  characters of the prefix field that can cause an XSS are transformed in a way the are not dangerous any more

### 💻 Technical Description *

The XSS payload was insertend in the html template without escaping the dangerous characters. The fix is the followings: in the apache.commons.text (already present in the pom of the project) there is a the method that HTML-escapes dangerous characters; using the method to render in a safe way the prefix field of the form in the html page  the the payload doesn't work any more

### 🐛 Proof of Concept (PoC) *

The video shows how the payload triggers the XSS after user creation. The version of the plugin is the one on the marketplace


https://user-images.githubusercontent.com/62958189/105394556-07871680-5c1e-11eb-990a-672430495a43.mp4



### 🔥 Proof of Fix (PoF) *

The video shows that the payload doesn't trigger XSS anymore thantk to escaping some characters. The version of the plugin is 1.4.1-SNAPSHOT.


https://user-images.githubusercontent.com/62958189/105394601-15d53280-5c1e-11eb-90c4-7e16354d22f5.mp4



### 👍 User Acceptance Testing (UAT)

After the fix, the page is still working correctly as before the fix and the XSS is not triggered anymore

